### PR TITLE
[FEAT]: 유저 프로필 업데이트 API 구현

### DIFF
--- a/src/main/java/com/rom/domain/record/application/RecordService.java
+++ b/src/main/java/com/rom/domain/record/application/RecordService.java
@@ -10,6 +10,7 @@ import com.rom.domain.user.domain.User;
 import com.rom.domain.user.domain.repository.UserRepository;
 import com.rom.global.DefaultAssert;
 import com.rom.global.config.security.token.UserPrincipal;
+import com.rom.global.infrastructure.S3Uploader;
 import com.rom.global.payload.ApiResponse;
 import com.rom.global.payload.Message;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/rom/domain/user/application/UserService.java
+++ b/src/main/java/com/rom/domain/user/application/UserService.java
@@ -1,13 +1,16 @@
 package com.rom.domain.user.application;
 
+import java.io.IOException;
 import java.util.Optional;
 
 import com.rom.domain.auth.domain.repository.TokenRepository;
 import com.rom.domain.user.dto.ChangePasswordReq;
+import com.rom.domain.user.dto.UpdateProfileReq;
 import com.rom.domain.user.dto.UserDetailRes;
 import com.rom.global.DefaultAssert;
 import com.rom.domain.user.domain.User;
 import com.rom.global.config.security.token.UserPrincipal;
+import com.rom.global.infrastructure.S3Uploader;
 import com.rom.global.payload.ApiResponse;
 import com.rom.domain.user.domain.repository.UserRepository;
 
@@ -18,6 +21,7 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -28,6 +32,7 @@ public class UserService {
     private final TokenRepository tokenRepository;
 
     private final PasswordEncoder passwordEncoder;
+    private final S3Uploader s3Uploader;
 
 
     public ResponseEntity<?> findUserById(Long id) {
@@ -88,4 +93,27 @@ public class UserService {
 
         return ResponseEntity.ok(apiResponse);
     }
+
+    @Transactional
+    public ResponseEntity<?> updateProfile(UserPrincipal userPrincipal, String nickname, MultipartFile profileImg) throws IOException {
+        Optional<User> user = userRepository.findById(userPrincipal.getId());
+        DefaultAssert.isTrue(user.isPresent(), "유저가 올바르지 않습니다.");
+
+        User findUser = user.get();
+
+        findUser.updateNickName(nickname);
+
+        if (!profileImg.isEmpty()) {
+            String storedFileName = s3Uploader.upload(profileImg, "profile_img");
+            findUser.updateImageUrl(storedFileName);
+        }
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(Message.builder().message("프로필이 업데이트 되었습니다").build())
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
 }

--- a/src/main/java/com/rom/domain/user/dto/UpdateProfileReq.java
+++ b/src/main/java/com/rom/domain/user/dto/UpdateProfileReq.java
@@ -1,0 +1,18 @@
+package com.rom.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+@Data
+public class UpdateProfileReq {
+
+    @Schema(type = "string", example = "nickname", description = "닉네임")
+    @NotBlank
+    private String nickname;
+
+    @Schema(type = "file", description = "이미지 파일")
+    private MultipartFile profileImg;
+
+}

--- a/src/main/java/com/rom/domain/user/presentation/UserController.java
+++ b/src/main/java/com/rom/domain/user/presentation/UserController.java
@@ -2,6 +2,7 @@ package com.rom.domain.user.presentation;
 
 import com.rom.domain.user.application.UserService;
 import com.rom.domain.user.dto.ChangePasswordReq;
+import com.rom.domain.user.dto.UpdateProfileReq;
 import com.rom.domain.user.dto.UserDetailRes;
 import com.rom.global.config.security.token.CurrentUser;
 import com.rom.global.config.security.token.UserPrincipal;
@@ -9,6 +10,7 @@ import com.rom.global.payload.ErrorResponse;
 import com.rom.global.payload.Message;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -16,8 +18,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Tag(name = "Users", description = "Users API")
 @RequiredArgsConstructor
@@ -63,4 +69,20 @@ public class UserController {
     ) {
         return userService.changePassword(userPrincipal, changePasswordReq);
     }
+
+    @Operation(summary = "이름, 프로필 사진 변경")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "이름, 프로필이 업데이트 되었습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}),
+            @ApiResponse(responseCode = "400", description = "이름, 프로필 업데이트에 실패했습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @PatchMapping(value = "/me", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> updateProfile(
+            @Parameter(description = "AccessToken을 입력해주세요", required = true) @CurrentUser UserPrincipal userPrincipal,
+            @Parameter(description = "닉네임을 입력해주세요.", required = true) @Valid @RequestPart String nickname,
+            @Parameter(description = "이미지를 업로드해주세요.") @RequestPart(required = false) MultipartFile profileImg
+
+            ) throws IOException {
+        return userService.updateProfile(userPrincipal, nickname, profileImg);
+    }
+
 }

--- a/src/main/java/com/rom/global/infrastructure/S3Uploader.java
+++ b/src/main/java/com/rom/global/infrastructure/S3Uploader.java
@@ -1,4 +1,4 @@
-package com.rom.domain.record.application;
+package com.rom.global.infrastructure;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;


### PR DESCRIPTION
## Related Issues

- close #

## 작업 내용

- [x] S3Uploader 클래스위치 /global/infrastructure/ 로 변경
- [x] 유저 닉네임, 프로필이미지 업데이트 API multipart/form-data 로 구현

## To Reviewers

```java
@PatchMapping(value = "/me", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
```

이렇게 consumes = MediaType.MULTIPART_FORM_DATA_VALUE 해주면
스웨거에서도 multipart/form-data 로 인식해서 RequestBody 에서 폼데이터로 표시하게 됩니다!

## 🔬 Reference