### PR TITLE
[FIX]: 유저 탈퇴할 때 Refresh 토큰도 같이 삭제 하도록 수정

### DIFF
--- a/src/main/java/com/rom/domain/user/application/UserService.java
+++ b/src/main/java/com/rom/domain/user/application/UserService.java
@@ -3,10 +3,10 @@ package com.rom.domain.user.application;
 import java.io.IOException;
 import java.util.Optional;
 
+import com.rom.domain.auth.domain.Token;
 import com.rom.domain.auth.domain.repository.TokenRepository;
 import com.rom.domain.common.Status;
 import com.rom.domain.user.dto.ChangePasswordReq;
-import com.rom.domain.user.dto.UpdateProfileReq;
 import com.rom.domain.user.dto.UserDetailRes;
 import com.rom.global.DefaultAssert;
 import com.rom.domain.user.domain.User;
@@ -112,6 +112,25 @@ public class UserService {
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)
                 .information(Message.builder().message("프로필이 업데이트 되었습니다").build())
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @Transactional
+    public ResponseEntity<?> deleteUser(UserPrincipal userPrincipal) {
+        Optional<User> user = userRepository.findById(userPrincipal.getId());
+        DefaultAssert.isTrue(user.isPresent(), "유저가 올바르지 않습니다");
+
+        User findUser = user.get();
+        findUser.updateStatus(Status.DELETE);
+
+        Optional<Token> token = tokenRepository.findByUserEmail(findUser.getEmail());
+        token.ifPresent(tokenRepository::delete);
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(Message.builder().message("유저 탈퇴가 완료되었습니다.").build())
                 .build();
 
         return ResponseEntity.ok(apiResponse);

--- a/src/main/java/com/rom/domain/user/presentation/UserController.java
+++ b/src/main/java/com/rom/domain/user/presentation/UserController.java
@@ -2,7 +2,6 @@ package com.rom.domain.user.presentation;
 
 import com.rom.domain.user.application.UserService;
 import com.rom.domain.user.dto.ChangePasswordReq;
-import com.rom.domain.user.dto.UpdateProfileReq;
 import com.rom.domain.user.dto.UserDetailRes;
 import com.rom.global.config.security.token.CurrentUser;
 import com.rom.global.config.security.token.UserPrincipal;
@@ -81,8 +80,20 @@ public class UserController {
             @Parameter(description = "닉네임을 입력해주세요.", required = true) @Valid @RequestPart String nickname,
             @Parameter(description = "이미지를 업로드해주세요.") @RequestPart(required = false) MultipartFile profileImg
 
-            ) throws IOException {
+    ) throws IOException {
         return userService.updateProfile(userPrincipal, nickname, profileImg);
+    }
+
+    @Operation(summary = "유저 탈퇴")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유저가 탈퇴되었습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = Message.class))}),
+            @ApiResponse(responseCode = "400", description = "유저 탈퇴에 실패했습니다.", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))})
+    })
+    @DeleteMapping("/me")
+    public ResponseEntity<?> deleteUser(
+            @Parameter(description = "AccessToken을 입력해주세요", required = true) @CurrentUser UserPrincipal userPrincipal
+    ) {
+        return userService.deleteUser(userPrincipal);
     }
 
 }


### PR DESCRIPTION
## Related Issues

- close # 

## 작업 내용

- [x] 유저 탈퇴 시 DB에 있는 토큰 레포지토리에 토큰이 있으면 삭제

## To Reviewers
- 


## 🔬 Reference
- 
